### PR TITLE
Use primary constructor in M3ManagmentContext class

### DIFF
--- a/Models/M3managmentContext.cs
+++ b/Models/M3managmentContext.cs
@@ -3,12 +3,8 @@
 
     using Microsoft.EntityFrameworkCore;
 
-    public class M3ManagmentContext : DbContext
+    public class M3ManagmentContext(DbContextOptions<M3ManagmentContext> options) : DbContext(options)
     {
-        public M3ManagmentContext(DbContextOptions<M3ManagmentContext> options)
-            : base(options){}
-        
-        
         public DbSet<Student> Student { get; set; }
         public DbSet<Teacher> Teacher { get; set; } 
     }


### PR DESCRIPTION
Fixes #6

Update `M3ManagmentContext` class to use primary constructor

* Use primary constructor for `M3ManagmentContext` class in `Models/M3managmentContext.cs`
* Remove explicit constructor from `M3ManagmentContext` class

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/BlessedDayss/M3App/pull/11?shareId=dbfc0f24-6804-4f22-a6a5-95bd75d69fb4).